### PR TITLE
uses channels over log.Logger

### DIFF
--- a/main.go
+++ b/main.go
@@ -53,7 +53,8 @@ func main() {
 
 	go coalesce(ch, wr)
 
-	http.Handle("/", Adapt(parseRequest(ch), checkShutdown(), ensurePost(), checkAuth(), parseCustomHeader))
+	// adapters are closures and therefore executed in reverse order
+	http.Handle("/", Adapt(parseRequest(ch), parseCustomHeader, checkAuth(), ensurePost(), checkShutdown()))
 	http.ListenAndServe(":"+port, nil)
 
 }

--- a/main.go
+++ b/main.go
@@ -2,21 +2,21 @@ package main
 
 import (
 	"flag"
-	"log"
-	"os"
 	"io"
+	"log"
 	"net/http"
+	"os"
 )
 
 var (
-	port           string         // the port on which to listen
-	pswd           string         // a simple means of authentication
-	forceStdout    bool           // skip disk io and allow output redirection
-	splitLineCount int            // how many lines per log file
-	splitByteCount int            // how many bytes per log file
-	splitPrefix    string         // the prefix for the log file(s) name
-	help           bool           // I forgot my options
-	bareLog        *log.Logger    // log to stderr without the timestamps
+	port           string      // the port on which to listen
+	pswd           string      // a simple means of authentication
+	forceStdout    bool        // skip disk io and allow output redirection
+	splitLineCount int         // how many lines per log file
+	splitByteCount int         // how many bytes per log file
+	splitPrefix    string      // the prefix for the log file(s) name
+	help           bool        // I forgot my options
+	bareLog        *log.Logger // log to stderr without the timestamps
 )
 
 func init() {
@@ -47,7 +47,7 @@ func main() {
 
 	if forceStdout {
 		wr = newWriteCloser(ioStdout)
-	}else{
+	} else {
 		wr = newWriteCloser(ioFile)
 	}
 
@@ -62,7 +62,7 @@ func main() {
 // coalesce runs in it's own goroutine and ranges over a channel and writing the
 // data to an io.Writer. All our goroutines send data on this channel and this
 // func coalesces them in to one stream.
-func coalesce (ch chan []byte, wr io.Writer) {
+func coalesce(ch chan []byte, wr io.Writer) {
 	for b := range ch {
 		wr.Write(append(b, '\n'))
 	}

--- a/main.go
+++ b/main.go
@@ -5,13 +5,11 @@ import (
 	"io"
 	"log"
 	"os"
-	"sync"
 	"net/http"
 )
 
 var (
 	out            io.Writer      // where to write the output
-	wg             sync.WaitGroup // ensure that our goroutines finish before shut down
 	port           string         // the port on which to listen
 	pswd           string         // a simple means of authentication
 	forceStdout    bool           // skip disk io and allow output redirection

--- a/main.go
+++ b/main.go
@@ -9,7 +9,7 @@ import (
 )
 
 var (
-	out            io.Writer      // where to write the output
+	// out            io.Writer      // where to write the output
 	port           string         // the port on which to listen
 	pswd           string         // a simple means of authentication
 	forceStdout    bool           // skip disk io and allow output redirection
@@ -45,14 +45,14 @@ func init() {
 }
 
 func main() {
-
+	var out io.Writer
 	if forceStdout {
 		out = getDest(ioStdout)
 	} else {
 		out = getDest(ioFile)
 	}
 
-	http.HandleFunc("/", handleWeb(out))
+	http.Handle("/", Adapt(parseRequest(out), checkShutdown(), ensurePost(), checkAuth(), parseCustomHeader))
 	http.ListenAndServe(":"+port, nil)
 
 }

--- a/shutdown.go
+++ b/shutdown.go
@@ -10,7 +10,7 @@ import (
 )
 
 var (
-	shutdownSig   int32 // atomically signal shutdown
+	shutdownSig int32 // atomically signal shutdown
 )
 
 // isShutdownMode checks to see if we're shutting down
@@ -19,7 +19,7 @@ func isShutdownMode() bool {
 	return s != 0
 }
 
-func signalShutdown(){
+func signalShutdown() {
 	atomic.AddInt32(&shutdownSig, 1)
 }
 

--- a/shutdown.go
+++ b/shutdown.go
@@ -10,7 +10,7 @@ import (
 )
 
 var (
-	shutdownSig   int32 // atomically signal shutdow
+	shutdownSig   int32 // atomically signal shutdown
 )
 
 // isShutdownMode checks to see if we're shutting down
@@ -33,7 +33,7 @@ func initShutdownWatcher() {
 		sig := <-c
 		bareLog.Printf("\n!Caught signal '%d: %s'; shutting down...\n", sig, sig.String())
 
-		// atomicly indicate we are in shutdown mode.
+		// atomically indicate we are in shutdown mode.
 		signalShutdown()
 
 		wg.Wait()

--- a/web.go
+++ b/web.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"bufio"
-	"io"
+	// "io"
 	"net/http"
 	"sync"
 )
@@ -18,8 +18,16 @@ var (
 	wg sync.WaitGroup // ensure that our goroutines finish before shut down
 )
 
+// defines a decorator that takes a handler and returns a handler. These functions
+// take a handler and return a handler. The returned handler does something before
+// calling the handler that was passed in. In this way, small pieces of logic can
+// broken into functions that are essentially chained together. Casting the returned
+// closure to http.HandlerFunc() allow a homogenious interface.
 type Adapter func(http.Handler) http.Handler
 
+// Adapt takes all of our adapters and runs them in order. The passed handler is
+// decorated in each step allowing small pieces of logic to be chained together
+// and wrapped around the base handler.
 func Adapt(h http.Handler, adapters ...Adapter) http.Handler {
 	for _, adapter := range adapters {
 		h = adapter(h)
@@ -27,10 +35,8 @@ func Adapt(h http.Handler, adapters ...Adapter) http.Handler {
 	return h
 }
 
-// scans the body of the POST request and writes each line. Currently prepends
-// the stream name (from the request header) to each line. This feature is less
-// useful each passing minute.
-
+// checkShutdown takes a handler and returns a handler that ensures we're not shutting
+// down before calling the passed handler
 func checkShutdown() Adapter {
 	return func(fn http.Handler) http.Handler {
 		return http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request){
@@ -45,7 +51,8 @@ func checkShutdown() Adapter {
 	}
 }
 
-// ensure a POST
+// ensurePost takes a handler and returns a handler that ensures the current request
+// is using the HTTP method POST before calling the passed handler
 func ensurePost() Adapter {
 	return func(fn http.Handler) http.Handler {
 		return http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request){
@@ -60,7 +67,10 @@ func ensurePost() Adapter {
 	}
 }
 
-// check the reqeust headers for the Authorization header (e.g. 'Authorization: Bearer this-is-a-string')
+// checkAuth takes a handler and returns a handler that checks the reqeust headers
+// for the Authorization header (e.g. 'Authorization: Bearer this-is-a-string')
+// and makes sure it matches the given password (if applicable) before calling the
+// passed handler
 func checkAuth() Adapter {
 	return func(fn http.Handler) http.Handler {
 		return http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request){
@@ -97,6 +107,9 @@ func checkAuth() Adapter {
 	}
 }
 
+// parseCustomHeader takes a handler and returns a handler that checks the request
+// headers for the 'X-Omnilog-Stream' header ... potentially making it's value useful
+// before calling the passed handler
 func parseCustomHeader(fn http.Handler) http.Handler {
 	return http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request){
 		// must have custom header (@TODO future stream separation?)
@@ -109,8 +122,9 @@ func parseCustomHeader(fn http.Handler) http.Handler {
 	})
 }
 
-
-func parseRequest(out io.Writer) http.Handler {
+// parseRequest returns a handler that reads the body of the request and sends
+// it on the channel to be coalesced
+func parseRequest(ch chan []byte) http.Handler {
 	return http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request){
 		// if we get here, don't let the program goroutine die before the goroutine finishes
 		wg.Add(1)
@@ -122,12 +136,8 @@ func parseRequest(out io.Writer) http.Handler {
 		scanner := bufio.NewScanner(req.Body)
 		for scanner.Scan() {
 
-			if isBrokenPipe() {
-				out = getDest(ioFile)
-			}
-
-			n, _ := out.Write(scanner.Bytes())
-			rn += n
+			ch <- scanner.Bytes()
+			rn += len(scanner.Bytes())
 
 			if err := scanner.Err(); err != nil {
 				break

--- a/web.go
+++ b/web.go
@@ -18,113 +18,122 @@ var (
 	wg sync.WaitGroup // ensure that our goroutines finish before shut down
 )
 
-type webHandler struct {
-	io.Writer
+type Adapter func(http.Handler) http.Handler
+
+func Adapt(h http.Handler, adapters ...Adapter) http.Handler {
+	for _, adapter := range adapters {
+		h = adapter(h)
+	}
+	return h
 }
 
 // scans the body of the POST request and writes each line. Currently prepends
 // the stream name (from the request header) to each line. This feature is less
 // useful each passing minute.
-func handleWeb(out io.Writer) http.HandlerFunc {
-	return parseCustomHeader(func(rw http.ResponseWriter, req *http.Request) {
-		// if we get here, don't let the program goroutine die before the goroutine finishes
-		wg.Add(1)
-		defer wg.Done() // cover the short-circuit returns
-		parseRequest(rw, req)
-	})
-}
 
-func checkShutdown(fn http.HandlerFunc) http.HandlerFunc {
-	return func(rw http.ResponseWriter, req *http.Request){
-		// graceful shutdown, reject new requests
-		if isShutdownMode() {
-			s := http.StatusServiceUnavailable
-			http.Error(rw, (newResponse(s, 0)).Json(), s)
-			return
-		}
-		fn(rw, req)
+func checkShutdown() Adapter {
+	return func(fn http.Handler) http.Handler {
+		return http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request){
+			// graceful shutdown, reject new requests
+			if isShutdownMode() {
+				s := http.StatusServiceUnavailable
+				http.Error(rw, (newResponse(s, 0)).Json(), s)
+				return
+			}
+			fn.ServeHTTP(rw, req)
+		})
 	}
 }
 
 // ensure a POST
-func ensurePost(fn http.HandlerFunc) http.HandlerFunc {
-	return checkShutdown(func(rw http.ResponseWriter, req *http.Request){
-		s := http.StatusMethodNotAllowed
-		// ensure a POST
-		if req.Method != methodPost {
-			http.Error(rw, (newResponse(s, 0)).Json(), s)
-			return
-		}
-		fn(rw, req)
-	})
+func ensurePost() Adapter {
+	return func(fn http.Handler) http.Handler {
+		return http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request){
+			s := http.StatusMethodNotAllowed
+			// ensure a POST
+			if req.Method != methodPost {
+				http.Error(rw, (newResponse(s, 0)).Json(), s)
+				return
+			}
+			fn.ServeHTTP(rw, req)
+		})
+	}
 }
 
 // check the reqeust headers for the Authorization header (e.g. 'Authorization: Bearer this-is-a-string')
-func checkAuth(fn http.HandlerFunc) http.HandlerFunc {
-	return ensurePost(func(rw http.ResponseWriter, req *http.Request){
-		// if no password was given to the server, leave the doors wide open
-		if pswd == "" {
-			fn(rw, req)
-			return
-		}
-
-		s := http.StatusForbidden
-
-		// make sure the header exists
-		a, ok := req.Header["Authorization"]
-		if !ok {
-			http.Error(rw, (newResponse(s, 0)).Json(), s)
-			return
-		}
-
-		// go returns a map, so loop over it
-		for _, v := range a {
-			// Bearer
-			if len(v) < 7 {
-				continue
-			}
-			if v[7:] == pswd {
-				fn(rw, req)
+func checkAuth() Adapter {
+	return func(fn http.Handler) http.Handler {
+		return http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request){
+			// if no password was given to the server, leave the doors wide open
+			if pswd == "" {
+				fn.ServeHTTP(rw, req)
 				return
 			}
-		}
 
-		http.Error(rw, (newResponse(s, 0)).Json(), s)
-		return
-	})
+			s := http.StatusForbidden
+
+			// make sure the header exists
+			a, ok := req.Header["Authorization"]
+			if !ok {
+				http.Error(rw, (newResponse(s, 0)).Json(), s)
+				return
+			}
+
+			// go returns a map, so loop over it
+			for _, v := range a {
+				// Bearer
+				if len(v) < 7 {
+					continue
+				}
+				if v[7:] == pswd {
+					fn.ServeHTTP(rw, req)
+					return
+				}
+			}
+
+			http.Error(rw, (newResponse(s, 0)).Json(), s)
+			return
+		})
+	}
 }
 
-func parseCustomHeader(fn http.HandlerFunc) http.HandlerFunc {
-	return checkAuth(func(rw http.ResponseWriter, req *http.Request){
+func parseCustomHeader(fn http.Handler) http.Handler {
+	return http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request){
 		// must have custom header (@TODO future stream separation?)
 		if _, ok := req.Header[customHeader]; !ok {
 			s := http.StatusBadRequest
 			http.Error(rw, (newResponse(s, 0)).Json(), s)
 			return
 		}
-		fn(rw, req)
+		fn.ServeHTTP(rw, req)
 	})
 }
 
-func parseRequest(rw http.ResponseWriter, req *http.Request){
-	defer req.Body.Close()
-	s := http.StatusOK
-	// read the request body
-	rn := 0
-	scanner := bufio.NewScanner(req.Body)
-	for scanner.Scan() {
 
-		if isBrokenPipe() {
-			out = getDest(ioFile)
+func parseRequest(out io.Writer) http.Handler {
+	return http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request){
+		// if we get here, don't let the program goroutine die before the goroutine finishes
+		wg.Add(1)
+		defer wg.Done() // cover the short-circuit returns
+		defer req.Body.Close()
+		s := http.StatusOK
+		// read the request body
+		rn := 0
+		scanner := bufio.NewScanner(req.Body)
+		for scanner.Scan() {
+
+			if isBrokenPipe() {
+				out = getDest(ioFile)
+			}
+
+			n, _ := out.Write(scanner.Bytes())
+			rn += n
+
+			if err := scanner.Err(); err != nil {
+				break
+			}
 		}
-
-		n, _ := out.Write(scanner.Bytes())
-		rn += n
-
-		if err := scanner.Err(); err != nil {
-			break
-		}
-	}
-
-	http.Error(rw, (newResponse(s, rn)).Json(), s)
+		http.Error(rw, (newResponse(s, rn)).Json(), s)
+	})
 }
+

--- a/web.go
+++ b/web.go
@@ -39,7 +39,7 @@ func Adapt(h http.Handler, adapters ...Adapter) http.Handler {
 // down before calling the passed handler
 func checkShutdown() Adapter {
 	return func(fn http.Handler) http.Handler {
-		return http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request){
+		return http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 			// graceful shutdown, reject new requests
 			if isShutdownMode() {
 				s := http.StatusServiceUnavailable
@@ -55,7 +55,7 @@ func checkShutdown() Adapter {
 // is using the HTTP method POST before calling the passed handler
 func ensurePost() Adapter {
 	return func(fn http.Handler) http.Handler {
-		return http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request){
+		return http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 			s := http.StatusMethodNotAllowed
 			// ensure a POST
 			if req.Method != methodPost {
@@ -73,7 +73,7 @@ func ensurePost() Adapter {
 // passed handler
 func checkAuth() Adapter {
 	return func(fn http.Handler) http.Handler {
-		return http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request){
+		return http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 			// if no password was given to the server, leave the doors wide open
 			if pswd == "" {
 				fn.ServeHTTP(rw, req)
@@ -111,7 +111,7 @@ func checkAuth() Adapter {
 // headers for the 'X-Omnilog-Stream' header ... potentially making it's value useful
 // before calling the passed handler
 func parseCustomHeader(fn http.Handler) http.Handler {
-	return http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request){
+	return http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 		// must have custom header (@TODO future stream separation?)
 		if _, ok := req.Header[customHeader]; !ok {
 			s := http.StatusBadRequest
@@ -125,7 +125,7 @@ func parseCustomHeader(fn http.Handler) http.Handler {
 // parseRequest returns a handler that reads the body of the request and sends
 // it on the channel to be coalesced
 func parseRequest(ch chan []byte) http.Handler {
-	return http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request){
+	return http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 		// if we get here, don't let the program goroutine die before the goroutine finishes
 		wg.Add(1)
 		defer wg.Done() // cover the short-circuit returns

--- a/web.go
+++ b/web.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"io"
 	"net/http"
+	"sync"
 )
 
 // A custom header previously used to name the stream(s) to prepend to the line
@@ -13,92 +14,117 @@ const (
 	methodPost   = "POST"
 )
 
+var (
+	wg sync.WaitGroup // ensure that our goroutines finish before shut down
+)
+
+type webHandler struct {
+	io.Writer
+}
+
 // scans the body of the POST request and writes each line. Currently prepends
 // the stream name (from the request header) to each line. This feature is less
 // useful each passing minute.
 func handleWeb(out io.Writer) http.HandlerFunc {
-	return func(w http.ResponseWriter, req *http.Request) {
-		defer req.Body.Close()
-
-		s := http.StatusServiceUnavailable
-
-		// graceful shutdown, reject new requests
-		if isShutdownMode() {
-			http.Error(w, (newResponse(s, 0)).Json(), s)
-			return
-		}
-
+	return parseCustomHeader(func(rw http.ResponseWriter, req *http.Request) {
 		// if we get here, don't let the program goroutine die before the goroutine finishes
 		wg.Add(1)
 		defer wg.Done() // cover the short-circuit returns
+		parseRequest(rw, req)
+	})
+}
 
-		s = http.StatusOK
-
-		// ensure a POST
-		if req.Method != methodPost {
-			s = http.StatusMethodNotAllowed
-		}
-
-		// must have custom header (@TODO future stream separation?)
-		if _, ok := req.Header[customHeader]; !ok {
-			s = http.StatusBadRequest
-		}
-
-		// check if the Authorization header matches the provided password
-		if !checkAuth(req.Header) {
-			s = http.StatusForbidden
-		}
-
-		if s != http.StatusOK {
-			http.Error(w, (newResponse(s, 0)).Json(), s)
+func checkShutdown(fn http.HandlerFunc) http.HandlerFunc {
+	return func(rw http.ResponseWriter, req *http.Request){
+		// graceful shutdown, reject new requests
+		if isShutdownMode() {
+			s := http.StatusServiceUnavailable
+			http.Error(rw, (newResponse(s, 0)).Json(), s)
 			return
 		}
-
-		// read the request body
-		rn := 0
-		scanner := bufio.NewScanner(req.Body)
-		for scanner.Scan() {
-
-			if isBrokenPipe() {
-				out = getDest(ioFile)
-			}
-
-			n, _ := out.Write(scanner.Bytes())
-			rn += n
-
-			if err := scanner.Err(); err != nil {
-				break
-			}
-		}
-
-		http.Error(w, (newResponse(s, rn)).Json(), s)
+		fn(rw, req)
 	}
 }
 
+// ensure a POST
+func ensurePost(fn http.HandlerFunc) http.HandlerFunc {
+	return checkShutdown(func(rw http.ResponseWriter, req *http.Request){
+		s := http.StatusMethodNotAllowed
+		// ensure a POST
+		if req.Method != methodPost {
+			http.Error(rw, (newResponse(s, 0)).Json(), s)
+			return
+		}
+		fn(rw, req)
+	})
+}
+
 // check the reqeust headers for the Authorization header (e.g. 'Authorization: Bearer this-is-a-string')
-func checkAuth(h http.Header) bool {
-
-	// if no password was given to the server, leave the doors wide open
-	if pswd == "" {
-		return true
-	}
-
-	// make sure the header exists
-	a, ok := h["Authorization"]
-	if !ok {
-		return false
-	}
-
-	// go returns a map, so loop over it
-	for _, v := range a {
-		// Bearer
-		if len(v) < 7 {
-			continue
+func checkAuth(fn http.HandlerFunc) http.HandlerFunc {
+	return ensurePost(func(rw http.ResponseWriter, req *http.Request){
+		// if no password was given to the server, leave the doors wide open
+		if pswd == "" {
+			fn(rw, req)
+			return
 		}
-		if v[7:] == pswd {
-			return true
+
+		s := http.StatusForbidden
+
+		// make sure the header exists
+		a, ok := req.Header["Authorization"]
+		if !ok {
+			http.Error(rw, (newResponse(s, 0)).Json(), s)
+			return
+		}
+
+		// go returns a map, so loop over it
+		for _, v := range a {
+			// Bearer
+			if len(v) < 7 {
+				continue
+			}
+			if v[7:] == pswd {
+				fn(rw, req)
+				return
+			}
+		}
+
+		http.Error(rw, (newResponse(s, 0)).Json(), s)
+		return
+	})
+}
+
+func parseCustomHeader(fn http.HandlerFunc) http.HandlerFunc {
+	return checkAuth(func(rw http.ResponseWriter, req *http.Request){
+		// must have custom header (@TODO future stream separation?)
+		if _, ok := req.Header[customHeader]; !ok {
+			s := http.StatusBadRequest
+			http.Error(rw, (newResponse(s, 0)).Json(), s)
+			return
+		}
+		fn(rw, req)
+	})
+}
+
+func parseRequest(rw http.ResponseWriter, req *http.Request){
+	defer req.Body.Close()
+	s := http.StatusOK
+	// read the request body
+	rn := 0
+	scanner := bufio.NewScanner(req.Body)
+	for scanner.Scan() {
+
+		if isBrokenPipe() {
+			out = getDest(ioFile)
+		}
+
+		n, _ := out.Write(scanner.Bytes())
+		rn += n
+
+		if err := scanner.Err(); err != nil {
+			break
 		}
 	}
 
-	return false
+	http.Error(rw, (newResponse(s, rn)).Json(), s)
 }

--- a/writecloser.go
+++ b/writecloser.go
@@ -19,7 +19,7 @@ func newWriteCloser(t int) io.WriteCloser {
 	case t == ioFile:
 		if splitByteCount > 0 {
 			writer = ws.ByteSplitter(splitByteCount, splitPrefix)
-		}else{
+		} else {
 			writer = ws.LineSplitter(splitLineCount, splitPrefix)
 		}
 	case t == ioStderr:

--- a/writecloser.go
+++ b/writecloser.go
@@ -3,7 +3,6 @@ package main
 import (
 	ws "github.com/henderjon/omnilogger/writesplitter"
 	"io"
-	"log"
 	"os"
 	"time"
 )
@@ -14,23 +13,8 @@ const (
 	ioStderr
 )
 
-type destination struct {
-	*log.Logger
-}
-
-// Write Satisfies io.WriteCloser but guaruntees atomicity via log
-func (d *destination) Write(s []byte) (int, error) {
-	d.Println(string(s)) // @TODO handle write errors
-	return len(s), nil
-}
-
-// Write Satisfies io.WriteCloser but guaruntees atomicity via log
-func (d *destination) Close() error {
-	return d.Close()
-}
-
 // getDest is a factory for various log destinations.
-func getDest(t int) io.WriteCloser {
+func newWriteCloser(t int) io.WriteCloser {
 	var writer io.WriteCloser
 	switch {
 	case t == ioFile:
@@ -47,5 +31,5 @@ func getDest(t int) io.WriteCloser {
 	case t == ioStdout:
 		writer = os.Stdout
 	}
-	return &destination{log.New(writer, "", 0)}
+	return writer
 }

--- a/writecloser.go
+++ b/writecloser.go
@@ -4,7 +4,6 @@ import (
 	ws "github.com/henderjon/omnilogger/writesplitter"
 	"io"
 	"os"
-	"time"
 )
 
 const (
@@ -13,16 +12,15 @@ const (
 	ioStderr
 )
 
-// getDest is a factory for various log destinations.
+// newWriteCloser is a factory for various io.WriteClosers.
 func newWriteCloser(t int) io.WriteCloser {
 	var writer io.WriteCloser
 	switch {
 	case t == ioFile:
-		writer = &ws.WriteSplitter{
-			LineLimit: splitLineCount,
-			ByteLimit: splitByteCount,
-			Prefix:    splitPrefix,
-			Created:   time.Now(),
+		if splitByteCount > 0 {
+			writer = ws.ByteSplitter(splitByteCount, splitPrefix)
+		}else{
+			writer = ws.LineSplitter(splitLineCount, splitPrefix)
 		}
 	case t == ioStderr:
 		writer = os.Stderr

--- a/writesplitter/writesplitter.go
+++ b/writesplitter/writesplitter.go
@@ -3,6 +3,7 @@ package writesplitter
 import (
 	"log"
 	"os"
+	"io"
 	"time"
 )
 
@@ -26,10 +27,20 @@ type WriteSplitter struct {
 	LineLimit int       // how many write ops (typically one per line) before splitting the file
 	ByteLimit int       // how many bytes before splitting the file
 	Prefix    string    // files are named "Prefix + nano-precision-timestamp.log"
-	Created   time.Time // track when this WriteSplitter was born
+	// Created   time.Time // track when this WriteSplitter was born
 	numBytes  int       // internal byte count
 	numLines  int       // internal line count
 	handle    *os.File  // embedded file
+}
+
+// LineSplitter returns a WriteSplitter set to split at the given number of lines
+func LineSplitter(limit int, prefix string) io.WriteCloser {
+	return &WriteSplitter{LineLimit: limit, Prefix: prefix}
+}
+
+// ByteSplitter returns a WriteSplitter set to split at the given number of bytes
+func ByteSplitter(limit int, prefix string) io.WriteCloser {
+	return &WriteSplitter{ByteLimit: limit, Prefix: prefix}
 }
 
 func init() {


### PR DESCRIPTION
log.Logger allows for goroutine safe file io but the funcs in the log package don't return data. Initially, I wanted to leverage a true io.Writer to get error messages from the underlying filesystem. As it turns out, the error I was hoping to catch isn't worth catching as it's not thrown and the check is more complicated than it's worth. In the process, using channels allowed me to remove _alot_ of wrapping code exposing a base io.WriteCloser. I'm into it. 

Also [this article](https://medium.com/@matryer/writing-middleware-in-golang-and-how-go-makes-it-so-much-fun-4375c1246e81#.42eboy1v0) gives a good overview of a basic middleware idiom ...
